### PR TITLE
Display ttyACM* devices in Serial Port list - Fixes #80526182

### DIFF
--- a/SerialPortCommunication/FrostedSerial/FrostedSerialPort.cs
+++ b/SerialPortCommunication/FrostedSerial/FrostedSerialPort.cs
@@ -754,7 +754,7 @@ namespace MatterHackers.SerialPortCommunication.FrostedSerial
                 // 
                 foreach (string dev in ttys)
                 {
-                    if (dev.StartsWith("/dev/ttyS") || dev.StartsWith("/dev/ttyUSB"))
+                    if (dev.StartsWith("/dev/ttyS") || dev.StartsWith("/dev/ttyUSB") || dev.StartsWith("/dev/ttyACM"))
                     {
                         linux_style = true;
                         break;
@@ -765,7 +765,7 @@ namespace MatterHackers.SerialPortCommunication.FrostedSerial
                 {
                     if (linux_style)
                     {
-                        if (dev.StartsWith("/dev/ttyS") || dev.StartsWith("/dev/ttyUSB"))
+                        if (dev.StartsWith("/dev/ttyS") || dev.StartsWith("/dev/ttyUSB") || dev.StartsWith("/dev/ttyACM"))
                             serial_ports.Add(dev);
                     }
                     else


### PR DESCRIPTION
This change allows my printer (connected as /dev/ttyACM0) to appear in the list of ports and subsequently provides a way to select and connect to the machine. After making this change, dropping the baud rate to 115200 and installing Arduino, as well as having **it** prompt to modify some config settings to allow my user account to read/write to serial ports, I was able to connect and control my RAMP driven printer.

![prusai3](https://cloud.githubusercontent.com/assets/175113/4608509/ec19c11a-5281-11e4-9ffa-48558b01ba7b.png)
