### PR TITLE
Limit Linux baud workaround to rates above 115200

### DIFF
--- a/SerialPortCommunication/FrostedSerial/FrostedSerialPortFactory.cs
+++ b/SerialPortCommunication/FrostedSerial/FrostedSerialPortFactory.cs
@@ -174,9 +174,10 @@ namespace MatterHackers.SerialPortCommunication.FrostedSerial
 			IFrostedSerialPort newPort = Create(serialPortName);
 
 			bool isLinux = !(newPort is FrostedSerialPort) && !IsWindows;
+			bool customBaudAssignment = isLinux && baudRate > 115200;
 
-			// Skip BaudRate assignment on Linux to avoid Invalid Baud exception - defaults to 9600
-			if (!isLinux)
+			// Only set serial port .BaudRate when not using Linux workaround
+			if (!customBaudAssignment)
 			{
 				newPort.BaudRate = baudRate;
 			}
@@ -192,7 +193,7 @@ namespace MatterHackers.SerialPortCommunication.FrostedSerial
 
 			newPort.Open();
 
-			if (isLinux)
+			if (customBaudAssignment)
 			{
 				// Once mono has enforced its ANSI baud rate policy(in SerialPort.Open), reset the baud rate to the user specified
 				// value by calling set_baud in libSetSerial.so

--- a/SerialPortCommunication/SerialHelper/build.sh
+++ b/SerialPortCommunication/SerialHelper/build.sh
@@ -1,10 +1,10 @@
 # Build libSetSerial.so
-gcc -shared -fPIC SetSerial.c -o libSetSerial.so -v
+gcc -m32 -shared -fPIC SetSerial.c -o libSetSerial.so -v
 
 # Create path if needed
-mkdir -p ../../../MatterControl/bin/Debug/
-mkdir -p ../../../MatterControl/bin/Release/
+mkdir -p ../../../../bin/Debug/
+mkdir -p ../../../../bin/Release/
 
 # Copy to MatterControl build directories
-cp libSetSerial.so ../../../MatterControl/bin/Debug/
-cp libSetSerial.so ../../../MatterControl/bin/Release/
+cp libSetSerial.so ../../../../bin/Debug/
+cp libSetSerial.so ../../../../bin/Release/


### PR DESCRIPTION
Ensure libSetSerial.so is compiled for x86 and only call set_baud workaround on Linux when needed. To build on Linux you likely need to add libc6-dev-i386 ala:

sudo apt-get install libc6-dev-i386
