### PR TITLE
Change SoftKeyboard.IsActive to manually set property

### DIFF
--- a/Gui/SoftKeyboard.cs
+++ b/Gui/SoftKeyboard.cs
@@ -316,13 +316,14 @@ namespace MatterHackers.Agg.UI
 
 	public class SoftKeyboardContentOffset : GuiWidget
 	{
-		private static TextEditWidget hadFocusWidget = null;
+		private TextEditWidget hadFocusWidget = null;
 		private GuiWidget content;
 		private GuiWidget contentOffsetHolder;
 
 		static SoftKeyboardContentOffset ()
 		{
 			KeyboardHeight = 253;
+			IsActive = false;
 		}
 
 		public SoftKeyboardContentOffset(GuiWidget content)
@@ -342,10 +343,8 @@ namespace MatterHackers.Agg.UI
 
 		public static bool IsActive 
 		{
-			get
-			{
-				return hadFocusWidget != null;
-			}
+			get;
+			private set;
 		}
 
 		private RectangleDouble TextWidgetScreenBounds()
@@ -378,6 +377,8 @@ namespace MatterHackers.Agg.UI
 			int topOfKeyboard = KeyboardHeight;
 			if (textWidgetScreenBounds.Bottom < topOfKeyboard)
 			{
+				IsActive = true;
+
 				// make sure the screen is not resizing vertically
 				content.VAnchor = VAnchor.AbsolutePosition;
 				// move the screen up so we can see the bottom of the text widget
@@ -391,6 +392,8 @@ namespace MatterHackers.Agg.UI
 			{
 				content.VAnchor = oldVAnchor;
 				content.OriginRelativeParent = oldOrigin;
+
+				IsActive = false;
 
 				// Clear focus so that future clicks into the original control will fire focus events that restore the keyboard view
 				hadFocusWidget.Unfocus();


### PR DESCRIPTION
 - Switch hadFocusWidget back to instance member
   - Duplicate ContentOffsets would null static member losing IsActive state
 - Fixes #106321662

The MoveContentBackDown function was testing if it should lower the keyboard by checking hadFocusWidget for null. I wasn't aware multiple ContentOffset controls would be active at the same time and the effect was that the first one nulled the static hadFocusWidget variable and the second one would test for and consider the keyboard already lowered.