### PR TITLE
IObject3D cache hits must be cloned rather than referenced

### DIFF
--- a/DataConverters3D/Object3D/Object3DExtensions.cs
+++ b/DataConverters3D/Object3D/Object3DExtensions.cs
@@ -79,6 +79,10 @@ namespace MatterHackers.PolygonMesh
 
 				itemCache[item.MeshPath] = loadedItem;
 			}
+			else
+			{
+				loadedItem = loadedItem.Clone();
+			}
 
 			// TODO: Consider refactoring progress reporting to use an instance with state and the original delegate reference to allow anyone along the chain
 			// to determine if continueProcessing has been set to false and allow for more clear aborting (rather than checking for null as we have to do below) 


### PR DESCRIPTION
 - Fixes drag issues with all instances pointing to a single reference