### PR TITLE
Refactor tab control, remove exceptions when requested pages missing

### DIFF
--- a/Gui/TabControl/Tab.cs
+++ b/Gui/TabControl/Tab.cs
@@ -128,7 +128,7 @@ namespace MatterHackers.Agg.UI
 		{
 			if (TabBarContaningTab != null)
 			{
-				bool selected = TabPageControlledByTab == TabBarContaningTab.GetActivePage();
+				bool selected = TabPage == TabBarContaningTab.GetActivePage();
 
 				if (selected)
 				{
@@ -150,7 +150,7 @@ namespace MatterHackers.Agg.UI
 			get { return (TabBar)Parent; }
 		}
 
-		public TabPage TabPageControlledByTab
+		public TabPage TabPage
 		{
 			get { return tabPageControledByTab; }
 		}

--- a/Gui/TabControl/TabControl.cs
+++ b/Gui/TabControl/TabControl.cs
@@ -144,7 +144,7 @@ namespace MatterHackers.Agg.UI
 			Tab tab = (Tab)tabBar.Children[index];
 			if (tab != null)
 			{
-				return tab.TabPageControlledByTab;
+				return tab.TabPage;
 			}
 
 			throw new Exception("Somehow there is an object in the tabBar that is not a Tab.");
@@ -157,7 +157,7 @@ namespace MatterHackers.Agg.UI
 				Tab tab = (Tab)child;
 				if (tab != null && tab.Text == tabName)
 				{
-					return tab.TabPageControlledByTab;
+					return tab.TabPage;
 				}
 			}
 
@@ -213,11 +213,6 @@ namespace MatterHackers.Agg.UI
 			return tabBar.SelectTab(tabName);
 		}
 
-		public void SwitchToPage(TabPage page)
-		{
-			tabBar.SwitchToPage(page);
-		}
-
 		public void AddTab(TabPage tabPageWidget, string internalTabName)
 		{
 			Tab newTab = new SimpleTextTabWidget(tabPageWidget, internalTabName);
@@ -226,7 +221,7 @@ namespace MatterHackers.Agg.UI
 
 		public void AddTab(Tab newTab)
 		{
-			TabPage tabPageWidget = newTab.TabPageControlledByTab;
+			TabPage tabPageWidget = newTab.TabPage;
 			tabPages.Add(tabPageWidget.Text, tabPageWidget);
 
 			switch (Orientation)


### PR DESCRIPTION
 - Issue MatterHackers/MatterControl#986
 - Use auto properties
 - Rename TabePageControlledByTab to TabPage
 - Remove excess TabPage setter (SwitchToPage)
 - Use Collection.Index of for SelectedIndex