### PR TITLE
Make sure clicking cancel in save dialog results in no file name.

### DIFF
--- a/WindowsFileDialogs/FileDialogPlugin.cs
+++ b/WindowsFileDialogs/FileDialogPlugin.cs
@@ -107,6 +107,10 @@ namespace MatterHackers.Agg.WindowsFileDialogs
 			{
 				SaveFileDialogDialogParams.FileName = saveFileDialog1.FileName;
 			}
+			else
+			{
+				SaveFileDialogDialogParams.FileName = null;
+			}
 
 			WidgetForWindowsFormsAbstract.MainWindowsFormsWindow.ShowingSystemDialog = false;
 

--- a/examples/GCodeVisualizer/GCodeFileLoaded.cs
+++ b/examples/GCodeVisualizer/GCodeFileLoaded.cs
@@ -890,7 +890,7 @@ namespace MatterHackers.GCodeVisualizer
 
 		public void Save(string dest)
 		{
-			using (System.IO.StreamWriter file = new System.IO.StreamWriter(dest))
+			using (StreamWriter file = new StreamWriter(dest))
 			{
 				foreach (PrinterMachineInstruction instruction in GCodeCommandQueue)
 				{


### PR DESCRIPTION
We use the filename is not null as a trigger to save.