### PR TITLE
Add LazyTabs for Touchscreen view

### DIFF
--- a/Gui/GUIWidget.cs
+++ b/Gui/GUIWidget.cs
@@ -1120,7 +1120,7 @@ namespace MatterHackers.Agg.UI
 			get { return (mouseCapturedState == MouseCapturedState.ChildHasMouseCaptured); }
 		}
 
-		public bool Visible
+		public virtual bool Visible
 		{
 			get
 			{

--- a/Gui/TabControl/Tab.cs
+++ b/Gui/TabControl/Tab.cs
@@ -86,7 +86,6 @@ namespace MatterHackers.Agg.UI
 	{
 		private RGBA_Bytes backgroundColor = new RGBA_Bytes(230, 230, 230);
 
-		private TabPage tabPageControledByTab;
 		protected GuiWidget normalWidget;
 		protected GuiWidget hoverWidget;
 		protected GuiWidget selectedWidget;
@@ -94,7 +93,7 @@ namespace MatterHackers.Agg.UI
 		public event EventHandler Selected;
 
 		public Tab(string tabName, GuiWidget normalWidget, GuiWidget hoverWidget, GuiWidget pressedWidget,
-			TabPage tabPageControledByTab)
+			TabPage tabPage)
 		{
 			base.Name = tabName;
 			this.normalWidget = normalWidget;
@@ -106,7 +105,7 @@ namespace MatterHackers.Agg.UI
 			AddChild(pressedWidget);
 			pressedWidget.Visible = false;
 			Padding = new BorderDouble(5, 3, 20, 3);
-			this.tabPageControledByTab = tabPageControledByTab;
+			this.TabPage = tabPage;
 			SetBoundsToEncloseChildren();
 		}
 
@@ -118,10 +117,7 @@ namespace MatterHackers.Agg.UI
 
 		public virtual void OnSelected(EventArgs e)
 		{
-			if (Selected != null)
-			{
-				Selected(this, e);
-			}
+			Selected?.Invoke(this, e);
 		}
 
 		public void SelectionChanged(object sender, EventArgs e)
@@ -150,30 +146,6 @@ namespace MatterHackers.Agg.UI
 			get { return (TabBar)Parent; }
 		}
 
-		public TabPage TabPage
-		{
-			get { return tabPageControledByTab; }
-		}
-
-		public override string Name
-		{
-			set
-			{
-				// You should not change this it is required for the interface to this tab.
-				GuiWidget.BreakInDebugger();
-			}
-		}
-
-		public override string Text
-		{
-			get
-			{
-				throw new Exception("You are probably looking for the Name not the text of a tab.");
-			}
-			set
-			{
-				throw new Exception("You are probably looking for the Name not the text of a tab.");
-			}
-		}
+		public TabPage TabPage { get; }
 	}
 }

--- a/Gui/TabControl/TabBar.cs
+++ b/Gui/TabControl/TabBar.cs
@@ -43,10 +43,10 @@ namespace MatterHackers.Agg.UI
 		public TabBar(FlowDirection direction, GuiWidget tabPageArea)
 			: base(direction)
 		{
-			this.TabPageArea = tabPageArea;
+			this.TabPageContainer = tabPageArea;
 		}
 
-		public GuiWidget TabPageArea { get; }
+		public GuiWidget TabPageContainer { get; }
 
 		public override void AddChild(GuiWidget child, int indexInChildrenList = -1)
 		{
@@ -162,16 +162,10 @@ namespace MatterHackers.Agg.UI
 		{
 			if (currentVisibleTab != tabToSwitchTo)
 			{
-				foreach (GuiWidget tabPage in TabPageArea.Children)
+				// Hide all but the current tab
+				foreach (GuiWidget tabPage in TabPageContainer.Children)
 				{
-					if (tabToSwitchTo.TabPage != tabPage)
-					{
-						tabPage.Visible = false;
-					}
-					else
-					{
-						tabPage.Visible = true;
-					}
+					tabPage.Visible = tabToSwitchTo.TabPage == tabPage;
 				}
 
 				currentVisibleTab = tabToSwitchTo;

--- a/Gui/TabControl/TabControl.cs
+++ b/Gui/TabControl/TabControl.cs
@@ -36,15 +36,7 @@ namespace MatterHackers.Agg.UI
 	// TODO: break this up into a model-controller and a view. LBB
 	public class TabControl : FlowLayoutWidget
 	{
-		internal class TabPageCollection : Dictionary<String, TabPage>
-		{
-			public new void Add(String key, TabPage tab)
-			{
-				base.Add(key, tab);
-			}
-		}
-
-		private TabPageCollection tabPages = new TabPageCollection();
+		public Dictionary<string, TabPage> TabPages = new Dictionary<string, TabPage>();
 
 		private StyledTypeFace typeFaceStyle = new StyledTypeFace(LiberationSansFont.Instance, 12);
 		private TabBar tabBar;
@@ -61,16 +53,16 @@ namespace MatterHackers.Agg.UI
 				orientation = value;
 				switch (orientation)
 				{
-					case UI.Orientation.Horizontal:
+					case Orientation.Horizontal:
 						FlowDirection = UI.FlowDirection.TopToBottom;
 						tabBar.FlowDirection = FlowDirection.LeftToRight;
 						tabBar.HAnchor = UI.HAnchor.ParentLeft | UI.HAnchor.ParentRight;
 						break;
 
-					case UI.Orientation.Vertical:
+					case Orientation.Vertical:
 						FlowDirection = UI.FlowDirection.LeftToRight;
 						tabBar.FlowDirection = FlowDirection.TopToBottom;
-						tabBar.VAnchor = UI.VAnchor.ParentTop | UI.VAnchor.ParentBottom;
+						tabBar.VAnchor = VAnchor.ParentTop | VAnchor.ParentBottom;
 						break;
 
 					default:
@@ -81,6 +73,12 @@ namespace MatterHackers.Agg.UI
 
 		public override void OnDraw(Graphics2D graphics2D)
 		{
+			// If no selection exists by the first draw, select index 0 if applicable
+			if (SelectedTabIndex == -1 && TabPages.Count > 0)
+			{
+				SelectedTabIndex = 0;
+			}
+
 			base.OnDraw(graphics2D);
 		}
 
@@ -89,12 +87,14 @@ namespace MatterHackers.Agg.UI
 			AnchorAll();
 
 			GuiWidget tabPageArea = new GuiWidget();
+
 			tabBar = new TabBar(FlowDirection.LeftToRight, tabPageArea);
-			//tabBar.LocalBounds = new RectangleDouble(0, 0, 20, 20);
+			
 			base.AddChild(tabBar);
-			//tabPageArea.BackgroundColor = new RGBA_Bytes(0, 255, 0, 50);
 			base.AddChild(tabPageArea);
+
 			tabPageArea.AnchorAll();
+
 			this.Orientation = orientation;
 		}
 
@@ -126,60 +126,9 @@ namespace MatterHackers.Agg.UI
 			}
 		}
 
-		public string SelectedTabName
-		{
-			get
-			{
-				return tabBar.SelectedTabName;
-			}
-		}
+		public string SelectedTabName => tabBar.SelectedTabName;
 
-		public TabPage GetTabPage(int index)
-		{
-			if (index >= tabBar.Children.Count)
-			{
-				throw new IndexOutOfRangeException();
-			}
-
-			Tab tab = (Tab)tabBar.Children[index];
-			if (tab != null)
-			{
-				return tab.TabPage;
-			}
-
-			throw new Exception("Somehow there is an object in the tabBar that is not a Tab.");
-		}
-
-		public TabPage GetTabPage(string tabName)
-		{
-			foreach (GuiWidget child in tabBar.Children)
-			{
-				Tab tab = (Tab)child;
-				if (tab != null && tab.Text == tabName)
-				{
-					return tab.TabPage;
-				}
-			}
-
-			throw new Exception("You asked to switch to a page that is not in the TabControl.");
-		}
-
-		public int TabCount
-		{
-			get
-			{
-				int tabCount = 0;
-				foreach (GuiWidget child in tabBar.Children)
-				{
-					Tab tab = child as Tab;
-					if (tab != null)
-					{
-						tabCount++;
-					}
-				}
-				return tabCount;
-			}
-		}
+		public int TabCount => TabPages.Count;
 
 		public void SelectTab(int index)
 		{
@@ -213,40 +162,30 @@ namespace MatterHackers.Agg.UI
 			return tabBar.SelectTab(tabName);
 		}
 
-		public void AddTab(TabPage tabPageWidget, string internalTabName)
-		{
-			Tab newTab = new SimpleTextTabWidget(tabPageWidget, internalTabName);
-			AddTab(newTab);
-		}
-
 		public void AddTab(Tab newTab)
 		{
 			TabPage tabPageWidget = newTab.TabPage;
-			tabPages.Add(tabPageWidget.Text, tabPageWidget);
+
+			// Use name, not text
+			TabPages.Add(newTab.Name, tabPageWidget);
 
 			switch (Orientation)
 			{
-				case UI.Orientation.Horizontal:
-					newTab.VAnchor = UI.VAnchor.ParentCenter;
+				case Orientation.Horizontal:
+					newTab.VAnchor = VAnchor.ParentCenter;
 					break;
 
-				case UI.Orientation.Vertical:
-					newTab.HAnchor = UI.HAnchor.ParentLeft | UI.HAnchor.ParentRight;
-
+				case Orientation.Vertical:
+					newTab.HAnchor = HAnchor.ParentLeft | HAnchor.ParentRight;
 					break;
 			}
+
 			tabBar.AddChild(newTab);
 
-			tabBar.TabPageArea.AddChild(tabPageWidget);
+			tabBar.TabPageContainer.AddChild(tabPageWidget);
 
-			if (tabBar.TabPageArea.Children.Count == 1)
-			{
-				tabBar.SelectTab(newTab);
-			}
-			else
-			{
-				tabPageWidget.Visible = false;
-			}
+			tabPageWidget.Visible = false;
 		}
 	}
 }
+ 

--- a/Gui/TabControl/TabControl.cs
+++ b/Gui/TabControl/TabControl.cs
@@ -126,6 +126,35 @@ namespace MatterHackers.Agg.UI
 			}
 		}
 
+		public TabPage GetTabPage(int index)
+		{
+			if (index >= tabBar.Children.Count)
+			{
+				throw new IndexOutOfRangeException();
+			}
+
+			Tab tab = (Tab)tabBar.Children[index];
+			if (tab != null)
+			{
+				return tab.TabPage;
+			}
+
+			throw new Exception("Somehow there is an object in the tabBar that is not a Tab.");
+		}
+
+		public TabPage GetTabPage(string tabName)
+		{
+			foreach (GuiWidget child in tabBar.Children)
+			{
+				Tab tab = (Tab)child;
+				if (tab != null && tab.Text == tabName)
+				{
+					return tab.TabPage;
+				}
+			}
+
+			throw new Exception("You asked to switch to a page that is not in the TabControl.");
+		}
 		public string SelectedTabName => tabBar.SelectedTabName;
 
 		public int TabCount => TabPages.Count;
@@ -160,6 +189,12 @@ namespace MatterHackers.Agg.UI
 		public bool SelectTab(string tabName)
 		{
 			return tabBar.SelectTab(tabName);
+		}
+
+		public void AddTab(TabPage tabPageWidget, string internalTabName)
+		{
+			Tab newTab = new SimpleTextTabWidget(tabPageWidget, internalTabName);
+			AddTab(newTab);
 		}
 
 		public void AddTab(Tab newTab)

--- a/Gui/TabControl/TabPage.cs
+++ b/Gui/TabControl/TabPage.cs
@@ -33,7 +33,7 @@ namespace MatterHackers.Agg.UI
 {
 	public class TabPage : GuiWidget
 	{
-		public TabPage(String tabTitle)
+		public TabPage(string tabTitle)
 		{
 			AnchorAll();
 			Text = tabTitle;
@@ -44,6 +44,50 @@ namespace MatterHackers.Agg.UI
 		{
 			widgetToAddToPage.AnchorAll();
 			AddChild(widgetToAddToPage);
+		}
+	}
+
+	/// <summary>
+	/// A TabPage widget which defers construction of its root widget until made visible
+	/// </summary>
+	public class LazyTabPage : TabPage
+	{
+		public Func<GuiWidget> Generator { get; set; }
+
+		private GuiWidget rootWidget = null;
+
+		public LazyTabPage(string tabTitle) : base(tabTitle)
+		{
+		}
+
+		public override bool Visible
+		{
+			get { return base.Visible; }
+			set
+			{
+				base.Visible = value;
+
+				if (value && rootWidget == null)
+				{
+					rootWidget = Generator();
+					rootWidget.AnchorAll();
+					AddChild(rootWidget);
+				}
+			}
+		}
+
+		public void Reload()
+		{
+			if (rootWidget != null)
+			{
+				rootWidget.Close();
+				rootWidget = null;
+			}
+
+			if (Visible)
+			{
+				Visible = true;
+			}
 		}
 	}
 }

--- a/agg/agg_color_rgba.cs
+++ b/agg/agg_color_rgba.cs
@@ -655,7 +655,7 @@ namespace MatterHackers.Agg
 		public byte red;
 		public byte alpha;
 
-		public static readonly RGBA_Bytes Transparent = new RGBA_Bytes(255, 255, 255, 0);
+		public static readonly RGBA_Bytes Transparent = new RGBA_Bytes(0, 0, 0, 0);
 		public static readonly RGBA_Bytes White = new RGBA_Bytes(255, 255, 255, 255);
 		public static readonly RGBA_Bytes LightGray = new RGBA_Bytes(225, 225, 225, 255);
 		public static readonly RGBA_Bytes Gray = new RGBA_Bytes(125, 125, 125, 235);


### PR DESCRIPTION
- Make GuiWidget.Visible virtual
- Switch Transparent color to low RGB, high alpha
- Use AutoProperty for Tab.TabPage
- Remove exceptions on property accessors
- Rename TabPageArea to TabPageContainer
- Remove TabPageCollection type
- Remove UI. prefix
- Don't automatically select the first tab for efficiency
  - On first draw, select the TabPage[0] if nothing is selected
- Remove dead code
- Proxy TabCount and SelectTabName to child objects
- Add LazyTab type
  - Defer widget construction to when first made visible
- Issue MatterHackers/MCCentral#536