### PR TITLE
Resolve easy to address build warnings

### DIFF
--- a/AggTests/AggDrawingTests.cs
+++ b/AggTests/AggDrawingTests.cs
@@ -9,8 +9,6 @@ namespace MatterHackers.Agg.Tests
 	[TestFixture]
 	public class AggDrawingTests
 	{
-		private bool saveTestToContrl = false;
-
 		public static void RunAllTests()
 		{
 			AggDrawingTests tests = new AggDrawingTests();

--- a/Gui/PerformanceTimer/PerformancePanel.cs
+++ b/Gui/PerformanceTimer/PerformancePanel.cs
@@ -96,8 +96,6 @@ namespace MatterHackers.Agg.UI
 			BackgroundColor = new RGBA_Bytes(RGBA_Bytes.White, 180);
 		}
 
-		private EventHandler unregisterEvents;
-
 		public static PerformancePanel GetNamedPanel(string panelName)
 		{
 			if (!resultsPanels.ContainsKey(panelName))
@@ -107,12 +105,6 @@ namespace MatterHackers.Agg.UI
 			}
 
 			return resultsPanels[panelName];
-		}
-
-		public override void OnClosed(ClosedEventArgs e)
-		{
-			unregisterEvents?.Invoke(this, null);
-			base.OnClosed(e);
 		}
 
 		public override void OnDraw(Graphics2D graphics2D)

--- a/MarchingSquares/MarchingSquaresByte.cs
+++ b/MarchingSquares/MarchingSquaresByte.cs
@@ -174,7 +174,7 @@ namespace MatterHackers.MarchingSquares
 								}
 								else
 								{
-									int i = 0;
+									// int i = 0;
 								}
 
 								if (foundNextSegment)

--- a/MarchingSquares/MarchingSquaresFloat.cs
+++ b/MarchingSquares/MarchingSquaresFloat.cs
@@ -111,7 +111,7 @@ namespace MatterHackers.MarchingSquares
 								}
 								else
 								{
-									int i = 0;
+									// int i = 0;
 								}
 
 								if (foundNextSegment)

--- a/PolygonMesh/Csg/CsgProcessing.cs
+++ b/PolygonMesh/Csg/CsgProcessing.cs
@@ -46,7 +46,7 @@ namespace MatterHackers.PolygonMesh.Csg
 
 	public class CsgAcceleratedMesh
 	{
-		int internalIntegerScale = 100;
+		//int internalIntegerScale = 100;
 
 		public CsgAcceleratedMesh(Mesh source)
 		{

--- a/PolygonMesh/Net3dBool/Object3D.cs
+++ b/PolygonMesh/Net3dBool/Object3D.cs
@@ -309,7 +309,7 @@ namespace Net3dBool
 											{
 												//System.out.println("possible infinite loop situation: terminating faces split");
 												//return;
-												int a = 0;
+												Console.WriteLine("possible infinite loop situation: terminating faces split");
 											}
 
 											//if the face in the position isn't the same, there was a break

--- a/RayTracer/RayTracer.cs
+++ b/RayTracer/RayTracer.cs
@@ -345,8 +345,7 @@ namespace MatterHackers.RayTracer
 					}
 				}
 				catch
-				{  
-					int stop = 0;
+				{
 				}
 			}
 		}
@@ -416,7 +415,6 @@ namespace MatterHackers.RayTracer
 						}
 						catch
 						{
-							int stop = 0;
 						}
 					}
 				}

--- a/agg/Font/StyledTypeFace.cs
+++ b/agg/Font/StyledTypeFace.cs
@@ -26,7 +26,6 @@ namespace MatterHackers.Agg.Font
 {
 	public class GlyphWithUnderline : VertexSourceLegacySupport
 	{
-		private int state = 0;
 		private IVertexSource underline;
 		private IVertexSource glyph;
 

--- a/agg/ImageLineRenderer.cs
+++ b/agg/ImageLineRenderer.cs
@@ -848,7 +848,7 @@ namespace MatterHackers.Agg
 		private int m_start;
 		private double m_scale_x;
 		private RectangleInt m_clip_box;
-		private bool m_clipping;
+		//private bool m_clipping;
 
 		//---------------------------------------------------------------------
 		//typedef renderer_outline_image<BaseRenderer, ImagePattern> self_type;
@@ -861,7 +861,7 @@ namespace MatterHackers.Agg
 			m_start = (0);
 			m_scale_x = (1.0);
 			m_clip_box = new RectangleInt(0, 0, 0, 0);
-			m_clipping = (false);
+			//m_clipping = (false);
 		}
 
 		public void attach(IImageByte ren)
@@ -883,7 +883,7 @@ namespace MatterHackers.Agg
 		//---------------------------------------------------------------------
 		public void reset_clipping()
 		{
-			m_clipping = false;
+			//m_clipping = false;
 		}
 
 		public void clip_box(double x1, double y1, double x2, double y2)
@@ -892,7 +892,7 @@ namespace MatterHackers.Agg
 			m_clip_box.Bottom = line_coord_sat.conv(y1);
 			m_clip_box.Right = line_coord_sat.conv(x2);
 			m_clip_box.Top = line_coord_sat.conv(y2);
-			m_clipping = true;
+			//m_clipping = true;
 		}
 
 		//---------------------------------------------------------------------

--- a/agg/VertexSource/Ellipse.cs
+++ b/agg/VertexSource/Ellipse.cs
@@ -36,7 +36,7 @@ namespace MatterHackers.Agg.VertexSource
 		public double radiusY;
 		private double m_scale;
 		private int numSteps;
-		private int m_step;
+		//private int m_step;
 		private bool m_cw;
 
 		public Ellipse()
@@ -47,7 +47,7 @@ namespace MatterHackers.Agg.VertexSource
 			radiusY = 1.0;
 			m_scale = 1.0;
 			numSteps = 4;
-			m_step = 0;
+			//m_step = 0;
 			m_cw = false;
 		}
 
@@ -69,7 +69,7 @@ namespace MatterHackers.Agg.VertexSource
 			this.radiusY = RadiusY;
 			m_scale = 1;
 			numSteps = num_steps;
-			m_step = 0;
+			//m_step = 0;
 			m_cw = cw;
 			if (numSteps == 0)
 			{
@@ -95,7 +95,7 @@ namespace MatterHackers.Agg.VertexSource
 			radiusX = RadiusX;
 			radiusY = RadiusY;
 			numSteps = num_steps;
-			m_step = 0;
+			//m_step = 0;
 			m_cw = cw;
 			if (numSteps == 0)
 			{

--- a/agg/VertexSource/FlattenCurve.cs
+++ b/agg/VertexSource/FlattenCurve.cs
@@ -50,8 +50,8 @@ namespace MatterHackers.Agg.VertexSource
 	//-----------------------------------------------------------------------
 	public class FlattenCurves : VertexSourceLegacySupport
 	{
-		private double lastX;
-		private double lastY;
+		//private double lastX;
+		//private double lastY;
 		private Curve3 m_curve3;
 		private Curve4 m_curve4;
 
@@ -66,8 +66,8 @@ namespace MatterHackers.Agg.VertexSource
 			m_curve3 = new Curve3();
 			m_curve4 = new Curve4();
 			VertexSource = vertexSource;
-			lastX = (0.0);
-			lastY = (0.0);
+			//lastX = (0.0);
+			//lastY = (0.0);
 		}
 
 		public double ApproximationScale

--- a/examples/GCodeVisualizer/GCodeFileLoaded.cs
+++ b/examples/GCodeVisualizer/GCodeFileLoaded.cs
@@ -143,7 +143,7 @@ namespace MatterHackers.GCodeVisualizer
 			return loadedGCode;
 		}
 
-		static public new void LoadInBackground(BackgroundWorker backgroundWorker, string fileName)
+		static public void LoadInBackground(BackgroundWorker backgroundWorker, string fileName)
 		{
 			if (Path.GetExtension(fileName).ToUpper() == ".GCODE")
 			{

--- a/examples/GCodeVisualizer/GCodeViewWidget.cs
+++ b/examples/GCodeVisualizer/GCodeViewWidget.cs
@@ -396,7 +396,7 @@ namespace MatterHackers.GCodeVisualizer
 			lastMousePosition = mousePos;
 		}
 
-		public void Load(string gcodePathAndFileName)
+		public void LoadFile(string gcodePathAndFileName)
 		{
 			loadedGCode = GCodeFile.Load(gcodePathAndFileName);
 			SetInitalLayer();

--- a/examples/GCodeVisualizer/GCodeViewerApplication.cs
+++ b/examples/GCodeVisualizer/GCodeViewerApplication.cs
@@ -88,7 +88,7 @@ namespace MatterHackers.GCodeVisualizer
 
 			if (gCodeToLoad != "")
 			{
-				gCodeViewWidget.Load(gCodeToLoad);
+				gCodeViewWidget.LoadFile(gCodeToLoad);
 			}
 			else
 			{
@@ -139,7 +139,7 @@ namespace MatterHackers.GCodeVisualizer
 		{
 			if (!string.IsNullOrEmpty(openParams.FileName))
 			{
-				gCodeViewWidget.Load(openParams.FileName);
+				gCodeViewWidget.LoadFile(openParams.FileName);
 				currentLayerIndex.Value = 0;
 				currentLayerIndex.MaxValue = gCodeViewWidget.LoadedGCode.NumChangesInZ;
 			}

--- a/examples/SimpleDrawAndSave/SimpleDrawAndSave.csproj
+++ b/examples/SimpleDrawAndSave/SimpleDrawAndSave.csproj
@@ -61,6 +61,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug64|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/examples/line_patterns/line_patterns.cs
+++ b/examples/line_patterns/line_patterns.cs
@@ -239,7 +239,7 @@ namespace MatterHackers.Agg
 			pattern_src_brightness_to_alpha_RGBA_Bytes p8 = new pattern_src_brightness_to_alpha_RGBA_Bytes(rbuf_img7);
 			pattern_src_brightness_to_alpha_RGBA_Bytes p9 = new pattern_src_brightness_to_alpha_RGBA_Bytes(rbuf_img8);
 
-			pattern_filter_bilinear_RGBA_Bytes fltr = new pattern_filter_bilinear_RGBA_Bytes();           // Filtering functor
+			//pattern_filter_bilinear_RGBA_Bytes fltr = new pattern_filter_bilinear_RGBA_Bytes();           // Filtering functor
 
 			// agg::line_image_pattern is the main container for the patterns. It creates
 			// a copy of the patterns extended according to the needs of the filter.


### PR DESCRIPTION
Reduces the warning count from 32 to 16, which are now spread across the following four issues:

1. `gsv_text` is obsolete: 'All of these should use the new font stuff.  You probably want a StringPrinter or a TextWidget in this spot.' *8 warnings*
1. Unreachable code detected - *6 warnings*
1. 'Mesh' overrides Object.Equals(object o) but does not override Object.GetHashCode() - *1 warning*
1. The variable 'invokeException' is declared but never used - *1 warning*

**Remaining**
![image](https://cloud.githubusercontent.com/assets/175113/24083696/4fa2052a-0c99-11e7-89ff-2faa7085bf38.png)

