### PR TITLE
Ensure popup menus are garbage collected on close

### DIFF
--- a/Gui/Menu/OpenMenuContents.cs
+++ b/Gui/Menu/OpenMenuContents.cs
@@ -117,6 +117,13 @@ namespace MatterHackers.Agg.UI
 			foreach (MenuItem menuItem in MenuItems)
 			{
 				menuItem.SendToChildren(new MenuItem.MenuClosedMessage());
+				menuItem.AllowClicks = null;
+			}
+
+			if (widgetRelativeTo != null)
+			{
+				widgetRelativeTo.Closed -= widgetRelativeTo_Closed;
+				widgetRelativeTo = null;
 			}
 
 			UnbindCallbacks();


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#1533
Popup menus appear to leak on 1.7+ due to unreleased event listeners