### PR TITLE
Eliminate hard-coded type names and IMappingType marker interface

### DIFF
--- a/DataConverters3D/Object3D/IObject3D.cs
+++ b/DataConverters3D/Object3D/IObject3D.cs
@@ -179,6 +179,8 @@ namespace MatterHackers.DataConverters3D
 		[JsonConverter(typeof(MatrixConverter))]
 		Matrix4X4 Matrix { get; set; }
 
+		string TypeName { get; }
+
 		Mesh Mesh { get; set; }
 		string MeshPath { get; set; }
 

--- a/DataConverters3D/Object3D/InteractiveScene.cs
+++ b/DataConverters3D/Object3D/InteractiveScene.cs
@@ -81,7 +81,7 @@ namespace MatterHackers.MeshVisualizer
 
 		[JsonIgnore]
 		public UndoBuffer UndoBuffer { get; } = new UndoBuffer();
-		
+
 		[JsonIgnore]
 		public bool HasSelection => this.HasChildren() && SelectedItem != null;
 
@@ -235,7 +235,7 @@ namespace MatterHackers.MeshVisualizer
 						list.Remove(SelectedItem);
 						list.Add(newSelectionGroup);
 					});
-					
+
 					SelectedItem = newSelectionGroup;
 				}
 			}

--- a/DataConverters3D/Object3D/Json/IObject3DChildrenConverter.cs
+++ b/DataConverters3D/Object3D/Json/IObject3DChildrenConverter.cs
@@ -35,13 +35,9 @@ using MatterHackers.Agg;
 
 namespace MatterHackers.DataConverters3D
 {
-	public interface IMappingType
-	{
-	}
-
 	public class IObject3DChildrenConverter : JsonConverter
 	{
-		// Register type mappings to support deserializing to the specified type via simple names
+		// Register type mappings to support deserializing to the IObject3D concrete type - long term hopefully via configuration mapping, short term via IObject3D inheritance
 		private Dictionary<string, string> mappingTypesCache;
 		private Dictionary<string, string> mappingTypes
 		{
@@ -49,18 +45,11 @@ namespace MatterHackers.DataConverters3D
 			{
 				if (mappingTypesCache == null)
 				{
-					mappingTypesCache = new Dictionary<string, string>()
-					{
-						["TextObject"] = "MatterHackers.PolygonMesh.TextObject,MatterHackers.DataConverters3D",
-						["CylinderObject3D"] = "MatterHackers.MatterControl.PartPreviewWindow.CylinderObject3D,EditorTools",
-						["ConeObject3D"] = "MatterHackers.MatterControl.PartPreviewWindow.ConeObject3D,EditorTools",
-						["CubeObject3D"] = "MatterHackers.MatterControl.PartPreviewWindow.CubeObject3D,EditorTools",
-						["OpenSCADObject3D"] = "MatterHackers.MatterControl.PartPreviewWindow.OpenSCADObject3D,EditorTools",
-					};
+					mappingTypesCache = new Dictionary<string, string>();
 
-					foreach (var type in PluginFinder.FindTypes<IMappingType>())
+					foreach (var type in PluginFinder.FindTypes<IObject3D>())
 					{
-						mappingTypesCache.Add(type.Name, type.FullName);
+						mappingTypesCache.Add(type.Name, type.AssemblyQualifiedName);
 					}
 				}
 

--- a/DataConverters3D/Object3D/Object3D.cs
+++ b/DataConverters3D/Object3D/Object3D.cs
@@ -47,6 +47,16 @@ namespace MatterHackers.DataConverters3D
 {
 	public class Object3D : IObject3D
 	{
+		public Object3D()
+		{
+			var type = this.GetType();
+			if (type != typeof(Object3D)
+				&& type.Name != "InteractiveScene")
+			{
+				this.TypeName = type.Name;
+			}
+		}
+
 		public static string AssetsPath { get; set; }
 
 		public string ID { get; set; }
@@ -55,6 +65,8 @@ namespace MatterHackers.DataConverters3D
 
 		public virtual string ActiveEditor { get; set; }
 		public SafeList<IObject3D> Children { get; set; } = new SafeList<IObject3D>();
+
+		public string TypeName { get; }
 
 		public IObject3D Parent { get; set; }
 
@@ -265,7 +277,7 @@ namespace MatterHackers.DataConverters3D
 				using (var stream = File.OpenRead(meshPath))
 				{
 					string extension = Path.GetExtension(meshPath).ToLower();
-					
+
 					loadedItem = Load(stream, extension, cancellationToken, itemCache, progress);
 
 					// Cache loaded assets

--- a/DataConverters3D/Object3D/TextObject.cs
+++ b/DataConverters3D/Object3D/TextObject.cs
@@ -36,6 +36,5 @@ namespace MatterHackers.PolygonMesh
 		public string Text { get; set; }
 		public double Spacing { get; set; }
 		public bool Underline { get; set; }
-		public string TypeName { get; } = nameof(TextObject);
 	}
 }


### PR DESCRIPTION
- All Object3D types must serialize their TypeName via IObject3D