### PR TITLE
Isolate Tab behavior in base type, extract multi-widget code to new type

### DIFF
--- a/Gui/TabControl/TabBar.cs
+++ b/Gui/TabControl/TabBar.cs
@@ -50,10 +50,9 @@ namespace MatterHackers.Agg.UI
 
 		public override void AddChild(GuiWidget child, int indexInChildrenList = -1)
 		{
-			Tab newTab = child as Tab;
-			if (newTab != null)
+			if (child is Tab newTab)
 			{
-				newTab.Selected += SwitchToTab;
+				newTab.Selected += Tab_Selected;
 			}
 			base.AddChild(child, indexInChildrenList);
 		}
@@ -117,8 +116,7 @@ namespace MatterHackers.Agg.UI
 			int tabCount = 0;
 			foreach (GuiWidget child in Children)
 			{
-				Tab tab = child as Tab;
-				if (tab != null)
+				if (child is Tab tab)
 				{
 					if (index == tabCount)
 					{
@@ -146,12 +144,11 @@ namespace MatterHackers.Agg.UI
 			return false;
 		}
 
-		private void SwitchToTab(object sender, EventArgs e)
+		private void Tab_Selected(object sender, EventArgs e)
 		{
 			UiThread.RunOnIdle(() =>
 			{
-				Tab clickedTab = (Tab) sender;
-				if (clickedTab != null)
+				if (sender is Tab clickedTab)
 				{
 					SelectTab(clickedTab);
 				}

--- a/Gui/TabControl/TabControl.cs
+++ b/Gui/TabControl/TabControl.cs
@@ -137,8 +137,7 @@ namespace MatterHackers.Agg.UI
 				throw new IndexOutOfRangeException();
 			}
 
-			Tab tab = (Tab)tabBar.Children[index];
-			if (tab != null)
+			if (tabBar.Children[index] is Tab tab)
 			{
 				return tab.TabPage;
 			}
@@ -165,8 +164,7 @@ namespace MatterHackers.Agg.UI
 			int tabCount = 0;
 			foreach (GuiWidget child in tabBar.Children)
 			{
-				Tab tab = child as Tab;
-				if (tab != null)
+				if (child is Tab tab)
 				{
 					foundTab = tab;
 					if (tabCount == index)
@@ -198,16 +196,16 @@ namespace MatterHackers.Agg.UI
 
 		public void AddTab(Tab newTab, int tabPosition = -1)
 		{
-			TabPage tabPageWidget = newTab.TabPage;
+			var tabPage = newTab.TabPage;
 
 			// Use name, not text
-			tabPages.Add(newTab.Name, tabPageWidget);
+			tabPages.Add(newTab.Name, tabPage);
 
 			tabBar.AddChild(newTab, tabPosition);
 
-			tabBar.TabPageContainer.AddChild(tabPageWidget);
+			tabBar.TabPageContainer.AddChild(tabPage);
 
-			tabPageWidget.Visible = false;
+			tabPage.Visible = false;
 		}
 	}
 }


### PR DESCRIPTION
Reduce complexity of base Tab type, allowing for simpler tab implementations without the requirement of multiple widget/viewwidget objects. Move classic Tab implementation to ThreeViewTab (normal, hover, selected) and update dependants