### PR TITLE
Limit number of rescale attempts, skip thumbgen on invalid items

### DIFF
--- a/MeshThumbnails/MeshThumbnails/ThumbnailEngine.cs
+++ b/MeshThumbnails/MeshThumbnails/ThumbnailEngine.cs
@@ -54,6 +54,13 @@ namespace MatterHackers.RayTracer
 	{
 		public static ImageBuffer Generate(IObject3D loadedItem, RenderType renderType, int width, int height, bool allowMultiThreading = true)
 		{
+			// Skip generation for invalid items
+			if (loadedItem.Children.Count == 0
+				|| !loadedItem.VisibleMeshes().Any())
+			{
+				return null;
+			}
+					
 			switch (renderType)
 			{
 				case RenderType.RAY_TRACE:

--- a/MeshThumbnails/MeshThumbnails/ThumbnailTracer.cs
+++ b/MeshThumbnails/MeshThumbnails/ThumbnailTracer.cs
@@ -388,7 +388,9 @@ namespace MatterHackers.RayTracer
 				double scaleFraction = .1;
 				RectangleDouble goalBounds = new RectangleDouble(0, 0, size.x, size.y);
 				goalBounds.Inflate(-10);
-				while (!done)
+
+				int rescaleAttempts = 0;
+				while (!done && rescaleAttempts++ < 500)
 				{
 					RectangleDouble partScreenBounds = GetScreenBounds(meshBounds);
 


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#2247
Thumbnail rendering hangs indefinitely on empty objects