### PR TITLE
Add OnInvalidate to Object3D

### DIFF
--- a/DataConverters3D/Object3D/Object3D.cs
+++ b/DataConverters3D/Object3D/Object3D.cs
@@ -347,7 +347,7 @@ namespace MatterHackers.DataConverters3D
 			return loadedItem;
 		}
 
-		public void Invalidate()
+		protected virtual void OnInvalidate()
 		{
 			Invalidated?.Invoke(this, null);
 
@@ -355,6 +355,11 @@ namespace MatterHackers.DataConverters3D
 			{
 				Parent.Invalidate();
 			}
+		}
+
+		public void Invalidate()
+		{
+			this.OnInvalidate();
 		}
 
 		// Deep clone via json serialization


### PR DESCRIPTION
- Give Object3D instances a chance to listen for Invadates without requiring event registration
- Issue MatterHackers/MCCentral#2276
No OnInvalidate virtual method on IObject3D instances