### PR TITLE
Ensure selection is first to be hit by mouse

### DIFF
--- a/DataConverters3D/Object3D/InteractiveScene.cs
+++ b/DataConverters3D/Object3D/InteractiveScene.cs
@@ -253,7 +253,8 @@ namespace MatterHackers.MeshVisualizer
 					{
 						list.Remove(itemToAdd);
 						list.Remove(SelectedItem);
-						list.Add(newSelectionGroup);
+						// add the seletionngroup as the first item so we can hit it first
+						list.Insert(0, newSelectionGroup);
 					});
 
 					SelectedItem = newSelectionGroup;

--- a/DataConverters3D/Object3D/Object3D.cs
+++ b/DataConverters3D/Object3D/Object3D.cs
@@ -208,17 +208,18 @@ namespace MatterHackers.DataConverters3D
 
 		public void EnsureTransparentSorting()
 		{
-			if (Mesh != null
-				&& Mesh.FaceBspTree == null
-				&& Mesh.Faces.Count < 2000
+			var localMesh = Mesh;
+			if (localMesh != null
+				&& localMesh.FaceBspTree == null
+				&& localMesh.Faces.Count < 2000
 				&& !buildingFaceBsp)
 			{
 				this.buildingFaceBsp = true;
 				Task.Run(() =>
 				{
 					// TODO: make a SHA1 based cache for the sorting on this mesh and use them from memory or disk
-					var bspTree = FaceBspTree.Create(Mesh);
-					UiThread.RunOnIdle(() => Mesh.FaceBspTree = bspTree);
+					var bspTree = FaceBspTree.Create(localMesh);
+					UiThread.RunOnIdle(() => localMesh.FaceBspTree = bspTree);
 					this.buildingFaceBsp = false;
 				});
 			}

--- a/agg/agg_basics.cs
+++ b/agg/agg_basics.cs
@@ -105,6 +105,11 @@ namespace MatterHackers.Agg
 
 		public static string GetNonCollidingName(string desiredName, Func<string, bool> IsUnique)
 		{
+			if (desiredName == null)
+			{
+				desiredName = "No Name";
+			}
+
 			if (IsUnique(desiredName))
 			{
 				return desiredName;


### PR DESCRIPTION
Fix crash in Transparent sorting
Improve unique name logic
Improved: MatterHackers/MCCentral#2401
Null reference exception when GetNonCollidingName param is null