### PR TITLE
Make EventHandler for Focused

### DIFF
--- a/DataConverters3D/Object3D/InteractiveScene.cs
+++ b/DataConverters3D/Object3D/InteractiveScene.cs
@@ -48,11 +48,17 @@ namespace MatterHackers.DataConverters3D
 	{
 		public event EventHandler SelectionChanged;
 		public event EventHandler Invalidated;
+		public event EventHandler Focused;
 
 		private IObject3D selectedItem;
 
 		public InteractiveScene()
 		{
+		}
+
+		public void Focus()
+		{
+			Focused?.Invoke(this, null);
 		}
 
 		[JsonIgnore]


### PR DESCRIPTION
issue: MatterHackers/MCCentral#2664
Toolbar buttons should push focus back to View3DWidget when clicked