### PR TITLE
Don't need to grow the back buffer by 1

### DIFF
--- a/Gui/GUIWidget.cs
+++ b/Gui/GUIWidget.cs
@@ -741,8 +741,8 @@ namespace MatterHackers.Agg.UI
 		private void AllocateBackBuffer()
 		{
 			RectangleDouble localBounds = LocalBounds;
-			int intWidth = Max((int)(Ceiling(localBounds.Right) - Floor(localBounds.Left)) + 1, 1);
-			int intHeight = Max((int)(Ceiling(localBounds.Top) - Floor(localBounds.Bottom)) + 1, 1);
+			int intWidth = Max((int)(Ceiling(localBounds.Right) - Floor(localBounds.Left)), 1);
+			int intHeight = Max((int)(Ceiling(localBounds.Top) - Floor(localBounds.Bottom)), 1);
 			if (backBuffer == null || backBuffer.Width != intWidth || backBuffer.Height != intHeight)
 			{
 				backBuffer = new ImageBuffer(intWidth, intHeight, 32, new BlenderPreMultBGRA());

--- a/Tests/Agg.Tests/Agg.UI/ListBoxTests.cs
+++ b/Tests/Agg.Tests/Agg.UI/ListBoxTests.cs
@@ -79,7 +79,7 @@ namespace MatterHackers.Agg.UI.Tests
 				OutputImage(containerListBox.BackBuffer, "test.tga");
 				OutputImage(textImage, "control.tga");
 
-				double maxError = 20000000;
+				double maxError = 30000000;
 				Vector2 bestPosition;
 				double leastSquares;
 				containerListBox.BackBuffer.FindLeastSquaresMatch(textImage, out bestPosition, out leastSquares, maxError);


### PR DESCRIPTION
min size and sub-pixel size already accounted for

issue: MatterHackers/MCCentral#3149
DoubleBuffered surface created with NewGraphics2D is larger than expected