### PR TITLE
Make responsive image cursor and click only happen on image

### DIFF
--- a/Gui/GUIWidget.cs
+++ b/Gui/GUIWidget.cs
@@ -3026,14 +3026,14 @@ namespace MatterHackers.Agg.UI
 			Click?.Invoke(this, mouseEvent);
 		}
 
-		protected virtual void SetCursorOnEnter(Cursors cursorToSet)
+		protected virtual void SetCursor(Cursors cursorToSet)
 		{
-			Parent?.SetCursorOnEnter(cursorToSet);
+			Parent?.SetCursor(cursorToSet);
 		}
 
 		public virtual void OnMouseEnter(MouseEventArgs mouseEvent)
 		{
-			SetCursorOnEnter(Cursor);
+			SetCursor(Cursor);
 			MouseEnter?.Invoke(this, mouseEvent);
 		}
 

--- a/Gui/ResponsiveImageWidget.cs
+++ b/Gui/ResponsiveImageWidget.cs
@@ -96,22 +96,67 @@ namespace MatterHackers.Agg.UI
 			}
 		}
 
+		Cursors overrideCursor = Cursors.Arrow;
+		public override void OnMouseMove(MouseEventArgs mouseEvent)
+		{
+			if (LocalBounds.Contains(mouseEvent.Position)
+				&& this.ContainsFocus)
+			{
+				if (ImageBounds.Contains(mouseEvent.Position))
+				{
+					overrideCursor = Cursor;
+				}
+				else
+				{
+					overrideCursor = Cursors.Arrow;
+				}
+				base.SetCursor(overrideCursor);
+			}
+
+			base.OnMouseMove(mouseEvent);
+		}
+
+		protected override void SetCursor(Cursors cursorToSet)
+		{
+			base.SetCursor(overrideCursor);
+		}
+
+		public override void OnClick(MouseEventArgs mouseEvent)
+		{
+			if (ImageBounds.Contains(mouseEvent.Position))
+			{
+				base.OnClick(mouseEvent);
+			}
+		}
+
 		public override void OnDraw(Graphics2D graphics2D)
 		{
 			if (image != null)
 			{
+				var imageBounds = ImageBounds;
+				graphics2D.Render(image,
+					ImageBounds.Left, ImageBounds.Bottom,
+					ImageBounds.Width, ImageBounds.Height);
+			}
+			base.OnDraw(graphics2D);
+		}
+
+		public RectangleDouble ImageBounds
+		{
+			get
+			{
 				if (Width > image.Width)
 				{
-					graphics2D.Render(image,
-						new Vector2(Width / 2 - image.Width / 2, Height / 2 - image.Height / 2),
-						image.Width, image.Height);
+					var left = new Vector2(Width / 2 - image.Width / 2, Height / 2 - image.Height / 2);
+					return new RectangleDouble(
+							left,
+							new Vector2(left.X + image.Width, left.Y + image.Height));
 				}
 				else
 				{
-					graphics2D.Render(image, Vector2.Zero, Width, Height);
+					return new RectangleDouble(0, 0, Width, Height);
 				}
 			}
-			base.OnDraw(graphics2D);
 		}
 	}
 }

--- a/Gui/SystemWindow/SystemWindow.cs
+++ b/Gui/SystemWindow/SystemWindow.cs
@@ -212,7 +212,7 @@ namespace MatterHackers.Agg.UI
 #endif
 		}
 
-		protected override void SetCursorOnEnter(Cursors cursorToSet)
+		protected override void SetCursor(Cursors cursorToSet)
 		{
 			PlatformWindow?.SetCursor(cursorToSet);
 		}


### PR DESCRIPTION
refactoring SetCursor to match winforms

issue: MatterHackers/MCCentral#3227
Non-image background still linked