### PR TITLE
Had a case where the agg system window was null

### DIFF
--- a/PlatformWin32/win32/WinformsSystemWindow.cs
+++ b/PlatformWin32/win32/WinformsSystemWindow.cs
@@ -542,7 +542,8 @@ namespace MatterHackers.Agg.UI
 					}
 
 					// Close the SystemWindow
-					if (!AggSystemWindow.HasBeenClosed)
+					if (AggSystemWindow != null 
+						&& !AggSystemWindow.HasBeenClosed)
 					{
 						// Store that the Close operation started here
 						winformAlreadyClosing = true;


### PR DESCRIPTION
seems to be non-destructive to test