### PR TITLE
Set Parent reference in SafeList constructor

### DIFF
--- a/DataConverters3D/Object3D/SafeList.cs
+++ b/DataConverters3D/Object3D/SafeList.cs
@@ -54,6 +54,13 @@ namespace MatterHackers.DataConverters3D
 		public SafeList(IEnumerable<T> sourceItems, T parent)
 		{
 			this.parentItem = parent;
+
+			// Ensure that new parent is pushed to children
+			foreach (var item in sourceItems)
+			{
+				item.Parent = parent;
+			}
+
 			items = new List<T>(sourceItems);
 		}
 


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#3518
When dragging a group of objects, the parts are not visible until
the move is completed