### PR TITLE
Added invalidate when resetting image index (fixed 1 frame gifs)

### DIFF
--- a/Gui/ImageSequenceWidget.cs
+++ b/Gui/ImageSequenceWidget.cs
@@ -90,6 +90,7 @@ namespace MatterHackers.Agg.UI
 		private void ResetImageIndex(object sender, EventArgs e)
 		{
 			currentTime = 0;
+			Invalidate();
 		}
 
 		public bool MaintainAspecRatio { get; set; } = true;


### PR DESCRIPTION
issue: MatterHackers/MCCentral#3568
What's New image fails to load for extended period of time