### PR TITLE
Design tools

### DIFF
--- a/DataConverters3D/DataConverters3D.csproj
+++ b/DataConverters3D/DataConverters3D.csproj
@@ -95,8 +95,8 @@
   <ItemGroup>
     <Compile Include="Object3D\AssetObject3D.cs" />
     <Compile Include="Object3D\ChildrenSelector.cs" />
-    <Compile Include="Object3D\SelectionGroup.cs" />
     <Compile Include="Object3D\SafeList.cs" />
+    <Compile Include="Object3D\SelectionGroupObject3D.cs" />
     <Compile Include="Object3D\UndoCommands\ReplaceCommand.cs" />
     <Compile Include="ObjParser\Types\IObjArray.cs" />
     <Compile Include="ObjParser\Types\ObjColor.cs" />

--- a/DataConverters3D/Object3D/InteractiveScene.cs
+++ b/DataConverters3D/Object3D/InteractiveScene.cs
@@ -83,7 +83,7 @@ namespace MatterHackers.DataConverters3D
 			{
 				if (selectedItem != value)
 				{
-					if (SelectedItem is SelectionGroup)
+					if (SelectedItem is SelectionGroupObject3D)
 					{
 						// If the selected item is a SelectionGroup, collapse its contents into the root
 						// of the scene when it loses focus
@@ -120,7 +120,7 @@ namespace MatterHackers.DataConverters3D
 
 				if (this.SelectedItem != null)
 				{
-					if (this.SelectedItem is SelectionGroup selectionGroup)
+					if (this.SelectedItem is SelectionGroupObject3D selectionGroup)
 					{
 						foreach (var item in selectionGroup.Children)
 						{
@@ -195,7 +195,7 @@ namespace MatterHackers.DataConverters3D
 			else
 			{
 				// Add a range of items wrapped with a new SelectionGroup
-				var SelectionGroup = new SelectionGroup(items)
+				var SelectionGroup = new SelectionGroupObject3D(items)
 				{
 					Name = "Selection".Localize()
 				};
@@ -225,7 +225,7 @@ namespace MatterHackers.DataConverters3D
 
 			if (this.HasSelection)
 			{
-				if (SelectedItem is SelectionGroup)
+				if (SelectedItem is SelectionGroupObject3D)
 				{
 					// Remove from the scene root
 					this.Children.Modify(list => list.Remove(itemToAdd));
@@ -238,7 +238,7 @@ namespace MatterHackers.DataConverters3D
 					// We're adding a new item to the selection. To do so we wrap the selected item
 					// in a new group and with the new item. The selection will continue to grow in this
 					// way until it's applied, due to a loss of focus or until a group operation occurs
-					var newSelectionGroup = new SelectionGroup(new[] { SelectedItem, itemToAdd })
+					var newSelectionGroup = new SelectionGroupObject3D(new[] { SelectedItem, itemToAdd })
 					{
 						Name = "Selection".Localize()
 					};
@@ -344,7 +344,7 @@ namespace MatterHackers.DataConverters3D
 
 				List<IObject3D> itemsToRestoreOnUndo;
 
-				if (this.SelectedItem is SelectionGroup selectionGroup)
+				if (this.SelectedItem is SelectionGroupObject3D selectionGroup)
 				{
 					item = new Object3D();
 					itemsToRestoreOnUndo = selectionGroup.Children.ToList();

--- a/DataConverters3D/Object3D/Object3D.cs
+++ b/DataConverters3D/Object3D/Object3D.cs
@@ -253,7 +253,7 @@ namespace MatterHackers.DataConverters3D
 							UiThread.RunOnIdle(() =>
 							{
 								rebuildLock.Dispose();
-								this.Invalidate(new InvalidateArgs(this, InvalidateType.Redraw, null));
+								this.Invalidate(new InvalidateArgs(this, InvalidateType.Mesh, null));
 							});
 						}
 						else // we still need to resume the building

--- a/DataConverters3D/Object3D/Object3DExtensions.cs
+++ b/DataConverters3D/Object3D/Object3DExtensions.cs
@@ -547,7 +547,7 @@ namespace MatterHackers.DataConverters3D
 		public static void CollapseInto(this IObject3D objectToCollapse, List<IObject3D> collapseInto, bool filterToSelectionGroup = true, int depth = int.MaxValue)
 		{
 			if (objectToCollapse != null
-				&& objectToCollapse is SelectionGroup == filterToSelectionGroup)
+				&& objectToCollapse is SelectionGroupObject3D == filterToSelectionGroup)
 			{
 				// Remove the collapsing item from the list
 				collapseInto.Remove(objectToCollapse);
@@ -572,7 +572,7 @@ namespace MatterHackers.DataConverters3D
 
 					child.Matrix *= objectToCollapse.Matrix;
 
-					if (child is SelectionGroup && depth > 0)
+					if (child is SelectionGroupObject3D && depth > 0)
 					{
 						child.CollapseInto(collapseInto, filterToSelectionGroup, depth - 1);
 					}

--- a/DataConverters3D/Object3D/SelectionGroupObject3D.cs
+++ b/DataConverters3D/Object3D/SelectionGroupObject3D.cs
@@ -32,15 +32,15 @@ using MatterHackers.DataConverters3D;
 
 namespace MatterHackers.DataConverters3D
 {
-	public class SelectionGroup : Object3D
+	public class SelectionGroupObject3D : Object3D
 	{
 		public override bool CanEdit => false;
 
-		public SelectionGroup()
+		public SelectionGroupObject3D()
 		{
 		}
 
-		public SelectionGroup(IEnumerable<IObject3D> children)
+		public SelectionGroupObject3D(IEnumerable<IObject3D> children)
 			: base (children)
 		{
 		}


### PR DESCRIPTION
Making Object3D classes consistent

issue: MatterHackers/MCCentral#3702
Consider adding 'Object3D' suffix to Object3D types or use consistent format