### PR TITLE
01: fix clip_liang_barsky

### DIFF
--- a/agg/agg_clip_liang_barsky.cs
+++ b/agg/agg_clip_liang_barsky.cs
@@ -246,7 +246,7 @@ namespace MatterHackers.Agg
 				{
 					return false;
 				}
-				bound = ((flags & (int)clipping_flags_e.clipping_flags_x1_clipped) != 0) ? clip_box.Bottom : clip_box.Top;
+				bound = ((flags & (int)clipping_flags_e.clipping_flags_y1_clipped) != 0) ? clip_box.Bottom : clip_box.Top;
 				x = (int)((double)(bound - y1) * (x2 - x1) / (y2 - y1) + x1);
 				y = bound;
 			}


### PR DESCRIPTION
This **must be** clipping_flags_y1_clipped
instead of
clipping_flags_x1_clipped

---

 
![agg_sharp_clip_liang_fix](https://user-images.githubusercontent.com/7447159/42366585-bda9868a-812b-11e8-835d-dbe280b06de0.png)

_(1) original agg, (2) after fix in aggsharp_
