### PR TITLE
Make sure we always layout FlowLeftRightWidthWrapping widget

### DIFF
--- a/Gui/FLowLeftRightWithWrapping.cs
+++ b/Gui/FLowLeftRightWithWrapping.cs
@@ -60,6 +60,13 @@ namespace MatterHackers.Agg.UI
 				Parent.BoundsChanged += Parent_BoundsChanged;
 			}
 			base.OnParentChanged(e);
+
+			UiThread.RunOnIdle(DoWrappingLayout);
+		}
+
+		public override void OnLoad(EventArgs args)
+		{
+			base.OnLoad(args);
 		}
 
 		bool doingLayout = false;

--- a/Gui/FLowLeftRightWithWrapping.cs
+++ b/Gui/FLowLeftRightWithWrapping.cs
@@ -61,6 +61,7 @@ namespace MatterHackers.Agg.UI
 			}
 			base.OnParentChanged(e);
 
+			// Make sure we always do a layout regardless of having a layout event or a draw.
 			UiThread.RunOnIdle(DoWrappingLayout);
 		}
 


### PR DESCRIPTION
issue: MatterHackers/MCCentral#3805
Markdown animated gifs fail to load until explicit invalidate