### PR TITLE
Make sure we have something in the undo data when we clear it

### DIFF
--- a/Gui/TextWidgets/InternalTextEditWidget.cs
+++ b/Gui/TextWidgets/InternalTextEditWidget.cs
@@ -1276,6 +1276,8 @@ namespace MatterHackers.Agg.UI
 		public void ClearUndoHistory()
 		{
 			undoBuffer.ClearHistory();
+			TextWidgetUndoCommand newUndoData = new TextWidgetUndoCommand(this);
+			undoBuffer.Add(newUndoData);
 		}
 	}
 }


### PR DESCRIPTION
issue: MatterHackers/MCCentral#3916
Slice settings text fields should get undo data set to cleared after initial setting