### PR TITLE
Fix for #3552 File Reader

### DIFF
--- a/DataConverters3D/AmfDocument.cs
+++ b/DataConverters3D/AmfDocument.cs
@@ -386,7 +386,7 @@ namespace MatterHackers.DataConverters3D
 
 										break;
 								}
-							} while (nextSibling != null && reader.ReadToNextSibling(nextSibling));
+							} while (nextSibling != null && (reader.Name != nextSibling ? reader.ReadToNextSibling(nextSibling) : true));
 						}
 
 						progressData.ReportProgress0To50();
@@ -450,7 +450,7 @@ namespace MatterHackers.DataConverters3D
 									nextSibling = null;
 									break;
 							}
-						} while (nextSibling != null && reader.ReadToNextSibling(nextSibling));
+						} while (nextSibling != null && (reader.Name != nextSibling ? reader.ReadToNextSibling(nextSibling) : true));
 					}
 
 					if (indices[0] != indices[1]


### PR DESCRIPTION
Fix for AMF file with no whitespace that AmfDocument reads incorrectly.
ReadElementAsInt positions the reader at the start of the next element, and ReadToNextSibling then skips over that element and fails to find the sibling element in the scope. This affected the X//Y/Z nodes as well as the v1/v2/v3 nodes. This caused the entire AMF to fail loading with no valid vertices and no valid faces.

Solution is to check if the XML reader is already positioned on the expected node before calling ReadToNextSibling.