### PR TITLE
Make flatten only copy appropriate properties by default

### DIFF
--- a/DataConverters3D/Object3D/IObject3D.cs
+++ b/DataConverters3D/Object3D/IObject3D.cs
@@ -310,13 +310,13 @@ namespace MatterHackers.DataConverters3D
 		bool CanEdit { get; }
 
 		[JsonIgnore]
-		bool CanApply { get; }
+		bool CanFlatten { get; }
 
 		/// <summary>
 		/// Remove the IObject3D from the tree and keep whatever functionality it was adding.
 		/// This may require removing many child objects from the tree depending on implementation.
 		/// </summary>
-		void Apply(UndoBuffer undoBuffer);
+		void Flatten(UndoBuffer undoBuffer);
 
 		/// <summary>
 		/// Remove the IObject3D from the tree and undo whatever functionality it was adding (if appropriate).

--- a/DataConverters3D/Object3D/InteractiveScene.cs
+++ b/DataConverters3D/Object3D/InteractiveScene.cs
@@ -289,7 +289,7 @@ namespace MatterHackers.DataConverters3D
 
 		public bool CanEdit => false;
 
-		public bool CanApply => false;
+		public bool CanFlatten => false;
 
 		public bool CanRemove => false;
 
@@ -318,7 +318,7 @@ namespace MatterHackers.DataConverters3D
 			return sourceItem.GetAxisAlignedBoundingBox(matrix);
 		}
 
-		public void Apply(UndoBuffer undoBuffer)
+		public void Flatten(UndoBuffer undoBuffer)
 		{
 			throw new NotImplementedException();
 		}

--- a/DataConverters3D/Object3D/Object3D.cs
+++ b/DataConverters3D/Object3D/Object3D.cs
@@ -282,7 +282,7 @@ namespace MatterHackers.DataConverters3D
 
 		public virtual bool Visible { get; set; } = true;
 
-		public virtual bool CanApply => false;
+		public virtual bool CanFlatten => false;
 		public virtual bool CanEdit => this.HasChildren();
 
 		[JsonIgnore]
@@ -787,7 +787,7 @@ namespace MatterHackers.DataConverters3D
 				});
 		}
 
-		public virtual void Apply(UndoBuffer undoBuffer)
+		public virtual void Flatten(UndoBuffer undoBuffer)
 		{
 			using (RebuildLock())
 			{
@@ -798,10 +798,11 @@ namespace MatterHackers.DataConverters3D
 					var newChild = child.Clone();
 					newChildren.Add(newChild);
 					newChild.Matrix *= this.Matrix;
-					newChild.CopyProperties(this, Object3DPropertyFlags.Color 
-						| Object3DPropertyFlags.MaterialIndex
-						| Object3DPropertyFlags.OutputType
-						| Object3DPropertyFlags.Visible);
+					var flags = Object3DPropertyFlags.Visible;
+					if (this.Color.alpha != 0) flags |= Object3DPropertyFlags.Color;
+					if (this.OutputType != PrintOutputTypes.Default) flags |= Object3DPropertyFlags.OutputType;
+					if (this.MaterialIndex != -1) flags |= Object3DPropertyFlags.MaterialIndex;
+					newChild.CopyProperties(this, flags);
 				}
 
 				// and replace us with the children


### PR DESCRIPTION
issue: MatterHackers/MCCentral#4229
Merge on align should not clear the colors that were on the objects

refactor apply and merge => flatten