### PR TITLE
always ensure text is set to a valid string

### DIFF
--- a/Gui/GUIWidget.cs
+++ b/Gui/GUIWidget.cs
@@ -1229,20 +1229,15 @@ namespace MatterHackers.Agg.UI
 
 		public string Name { get; set; }
 
-		private string text = "";
+		private string _text = "";
 		public virtual string Text
 		{
-			get => text;
+			get => _text;
 			set
 			{
-				if (value == null)
+				if (_text != value)
 				{
-					throw new ArgumentNullException("You cannot set the Text to null.");
-				}
-				if (text != value)
-				{
-					Invalidate(); // do it before and after in case it changes size.
-					text = value;
+					_text = value ?? "";
 					OnTextChanged(null);
 					Invalidate();
 				}


### PR DESCRIPTION
issue: MatterHackers/MCCentral#4499
Allow GuiWidget.Text setter to receive null values