### PR TITLE
Revise TransformToScreenSpace to walk to topmost parent

### DIFF
--- a/Gui/GUIWidget.cs
+++ b/Gui/GUIWidget.cs
@@ -2378,8 +2378,9 @@ namespace MatterHackers.Agg.UI
 		{
 			GuiWidget prevGUIWidget = this;
 
+			// Walk until we find a SystemWindow with a null parent or until the topmost GuiWidget
 			while (prevGUIWidget != null
-				&& !(prevGUIWidget is SystemWindow))
+				&& !(prevGUIWidget is SystemWindow && prevGUIWidget.Parent == null))
 			{
 				vectorToTransform += prevGUIWidget.OriginRelativeParent;
 				prevGUIWidget = prevGUIWidget.Parent;


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#4775
Popovers appear at incorrect position in presets window