### PR TITLE
Made the mesh aabb cache hold up to 100 matrix caches

### DIFF
--- a/DataConverters3D/CenterAndHeightMantainer.cs
+++ b/DataConverters3D/CenterAndHeightMantainer.cs
@@ -1,0 +1,66 @@
+﻿/*
+Copyright (c) 2018, Lars Brubaker, John Lewin
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the FreeBSD Project.
+*/
+
+using System;
+using MatterHackers.DataConverters3D;
+using MatterHackers.VectorMath;
+
+namespace MatterHackers.DataConverters3D
+{
+	public class CenterAndHeightMantainer : IDisposable
+	{
+		private IObject3D item;
+		private AxisAlignedBoundingBox aabb;
+
+		public CenterAndHeightMantainer(IObject3D item)
+		{
+			this.item = item;
+			aabb = item.GetAxisAlignedBoundingBox();
+		}
+
+		public void Dispose()
+		{
+			// make sure we have some size in z
+			if (aabb.ZSize > 0)
+			{
+				// get the current bounds
+				var newAabbb = item.GetAxisAlignedBoundingBox();
+
+				// move our center back to where our center was
+				item.Matrix *= Matrix4X4.CreateTranslation(aabb.Center - newAabbb.Center);
+
+				// update the bounds again
+				newAabbb = item.GetAxisAlignedBoundingBox();
+
+				// Make sure we also maintain our height
+				item.Matrix *= Matrix4X4.CreateTranslation(new Vector3(0, 0, aabb.MinXYZ.Z - newAabbb.MinXYZ.Z));
+			}
+		}
+	}
+}

--- a/DataConverters3D/Object3D/UndoCommands/ReplaceCommand.cs
+++ b/DataConverters3D/Object3D/UndoCommands/ReplaceCommand.cs
@@ -31,6 +31,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using MatterHackers.Agg.UI;
+using MatterHackers.VectorMath;
 
 namespace MatterHackers.DataConverters3D.UndoCommands
 {
@@ -63,15 +64,43 @@ namespace MatterHackers.DataConverters3D.UndoCommands
 		public void Do()
 		{
 			var firstParent = removeItems.First().Parent;
-			firstParent.Children.Modify(list =>
+			using (firstParent.RebuildLock())
 			{
-				foreach (var child in removeItems)
+				var aabb = firstParent.GetAxisAlignedBoundingBox();
+
+				firstParent.Children.Modify(list =>
 				{
-					list.Remove(child);
+					foreach (var child in removeItems)
+					{
+						list.Remove(child);
+					}
+					list.AddRange(addItems);
+				});
+
+				// attempt to hold the items that we are adding to the same position as the items we are replacing
+				// first get the bounds of all the items being added
+				var aabb2 = AxisAlignedBoundingBox.Empty();
+				foreach(var item in addItems)
+				{
+					aabb2 += item.GetAxisAlignedBoundingBox();
 				}
-				list.AddRange(addItems);
-			});
-			firstParent.Invalidate(new InvalidateArgs(firstParent, InvalidateType.Children));
+
+				// then move the all to account for the old center and bed position
+				foreach (var item in addItems)
+				{
+					if (aabb.ZSize > 0)
+					{
+						// move our center back to where our center was
+						var centerDelta = (aabb.Center - aabb2.Center);
+						centerDelta.Z = 0;
+						item.Matrix *= Matrix4X4.CreateTranslation(centerDelta);
+
+						// Make sure we also maintain our height
+						item.Matrix *= Matrix4X4.CreateTranslation(new Vector3(0, 0, aabb.MinXYZ.Z - aabb2.MinXYZ.Z));
+					}
+				}
+			}
+			firstParent.Invalidate(new InvalidateArgs(firstParent, InvalidateType.Children | InvalidateType.Matrix));
 		}
 
 		public void Undo()


### PR DESCRIPTION
This would allow dragged text with up to 100 same characters (like
and 'e') not need to calculate a new aabb. All the 'e's are sharing
a mesh and the mesh has a transform for each Object3Ds position

We could make a better cache if we have some type of recency information.
Right now when we get past 100 we just clear the list. We would be a 
lot faster if we kept the last 100 hits and then removed non-hit data
at some rate.

issue: MatterHackers/MCCentral#4951
Make AABB cache hold n items