### PR TITLE
Ensure NextElementIsANumber false when parseIndex == dString.Length

### DIFF
--- a/agg/VertexSource/VertexStorage.cs
+++ b/agg/VertexSource/VertexStorage.cs
@@ -985,7 +985,8 @@ namespace MatterHackers.Agg.VertexSource
 				parseIndex++;
 			}
 
-			if (validNumberStartingCharacters.Contains(dString[parseIndex]))
+			if (parseIndex < dString.Length
+				&& validNumberStartingCharacters.Contains(dString[parseIndex]))
 			{
 				return true;
 			}


### PR DESCRIPTION
Fixes observed exception with `Freesample.svg`