### PR TITLE
create new sub mesh when switch from a textured to non-textured

### DIFF
--- a/RenderOpenGl/GLMeshTrianglePlugin.cs
+++ b/RenderOpenGl/GLMeshTrianglePlugin.cs
@@ -140,7 +140,9 @@ namespace MatterHackers.RenderOpenGl
 				// don't compare the data of the texture but rather if they are just the same object
 				if (subMeshs.Count == 0 
 					|| (faceTexture != null 
-						&& (object)subMeshs[subMeshs.Count - 1].texture != (object)faceTexture.image))
+						&& (object)subMeshs[subMeshs.Count - 1].texture != (object)faceTexture.image)
+					|| (faceTexture == null 
+						&& subMeshs[subMeshs.Count - 1].texture != null))
 				{
 					SubTriangleMesh newSubMesh = new SubTriangleMesh();
 					newSubMesh.texture = faceTexture == null ? null : faceTexture.image;


### PR DESCRIPTION
When creating sub-meshes for a given mesh in the gl render data,
switch to a new one if we are going from a texture group to a non-texture group

issue: MatterHackers/MCCentral#5331
Bed mesh no longer detectable