### PR TITLE
The font cache was expecting the bounds to start at 0

### DIFF
--- a/agg/Font/StyledTypeFace.cs
+++ b/agg/Font/StyledTypeFace.cs
@@ -202,7 +202,7 @@ namespace MatterHackers.Agg.Font
 			var bounds = glyphForCharacter.GetBounds();
 
 			var charImage = new ImageBuffer(
-				Math.Max((int)(bounds.Width + .5), 1) + 1,
+				Math.Max((int)(bounds.Right + .5), 1) + 1,
 				Math.Max((int)Math.Ceiling(EmSizeInPixels + (-DescentInPixels) + .5), 1) + 1,
 				32,
 				new BlenderPreMultBGRA());


### PR DESCRIPTION
This change is due to the fix in the IVertex source bounds being right.
They used to always start at 0,0 and that was a bug that this code had
taken a dependency on.

issue: MatterHackers/MCCentral#5506
Terminal incorrectly reports line sent