### PR TITLE
Use HashSet for SelectedChildren

### DIFF
--- a/DataConverters3D/Object3D/SelectedChildren.cs
+++ b/DataConverters3D/Object3D/SelectedChildren.cs
@@ -31,7 +31,7 @@ using System.Collections.Generic;
 
 namespace MatterHackers.DataConverters3D
 {
-	public class SelectedChildren : List<string>
+	public class SelectedChildren : HashSet<string>
 	{
 		public override string ToString()
 		{


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#5565
MatterControl extra slow with specific MCX, crashes on copy