### PR TITLE
don't scroll into view a control that is already in view

### DIFF
--- a/Gui/ScrollableWidget/ScrollableWidget.cs
+++ b/Gui/ScrollableWidget/ScrollableWidget.cs
@@ -375,9 +375,12 @@ namespace MatterHackers.Agg.UI
 		{
 			if (this.Descendants().Contains(widget))
 			{
-				var widgetScreenBounds = widget.TransformToScreenSpace(widget.LocalBounds);
-				var widgetScrollBounds = this.TransformFromScreenSpace(widgetScreenBounds.Center);
-				this.ScrollPosition = new Vector2(0, -widgetScrollBounds.Y);
+				if (!widget.ActuallyVisibleOnScreen())
+				{
+					var widgetScreenBounds = widget.TransformToScreenSpace(widget.LocalBounds);
+					var widgetScrollBounds = this.TransformFromScreenSpace(widgetScreenBounds.Center);
+					this.ScrollPosition = new Vector2(0, -widgetScrollBounds.Y);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
issue: MatterHackers/MCCentral#5723
Tree view shifting when user selecting nodes