### PR TITLE
Pass test runner to close action

### DIFF
--- a/GuiAutomation/AutomationRunner.cs
+++ b/GuiAutomation/AutomationRunner.cs
@@ -1191,7 +1191,7 @@ namespace MatterHackers.GuiAutomation
 
 		public static bool DrawSimulatedMouse { get; set; } = true;
 
-		public static Task ShowWindowAndExecuteTests(SystemWindow initialSystemWindow, AutomationTest testMethod, double secondsToTestFailure = 30, string imagesDirectory = "", Action closeWindow = null)
+		public static Task ShowWindowAndExecuteTests(SystemWindow initialSystemWindow, AutomationTest testMethod, double secondsToTestFailure = 30, string imagesDirectory = "", Action<AutomationRunner> closeWindow = null)
 		{
 			var testRunner = new AutomationRunner(InputMethod, DrawSimulatedMouse, imagesDirectory);
 
@@ -1228,7 +1228,7 @@ namespace MatterHackers.GuiAutomation
 				// Invoke the callers close implementation or fall back to CloseOnIdle
 				if (closeWindow != null)
 				{
-					closeWindow();
+					closeWindow(testRunner);
 				}
 				else
 				{


### PR DESCRIPTION
This part of a fix for MatterControl issue MatterHackers/MatterControl#5198. It lets the automation harness dismiss the save changes dialog that pops up for some tests when the main application is closed.