### PR TITLE
Allow automation tests to override modifiers on OpenGL system window

### DIFF
--- a/PlatformWin32/win32/OpenGLSystemWindow.cs
+++ b/PlatformWin32/win32/OpenGLSystemWindow.cs
@@ -239,6 +239,24 @@ namespace MatterHackers.Agg.UI
 
 		private bool initHasBeenCalled = false;
 
-		public override Keys ModifierKeys => base.ModifierKeys;
+		private Keys modifierKeys = Keys.None;
+		private bool modifiersOverridden = false;
+
+		internal void SetModifierKeys(Keys modifiers)
+		{
+			modifierKeys = modifiers;
+			modifiersOverridden = true;
+		}
+
+		public override Keys ModifierKeys
+		{
+			get {
+				if (modifiersOverridden)
+				{
+					return modifierKeys;
+				}
+				return base.ModifierKeys;
+			}
+		}
 	}
 }


### PR DESCRIPTION
The automation tests bypass the native platform eventing to synthesize
keyboard events. However, not all operations in MatterControl look directly
at the keyboard state but instead rely on the ModifierKeys property of the
system window. Therefore, the automation tests must both set the keyboard
state and the modifier keys on the system window.

This goes with the PR for   MatterHackers/MatterControl#5188
