### PR TITLE
Changes for orthographic view mode

### DIFF
--- a/PolygonMesh/RayTracer/Primitive/Shapes/PlaneShape.cs
+++ b/PolygonMesh/RayTracer/Primitive/Shapes/PlaneShape.cs
@@ -75,6 +75,29 @@ namespace MatterHackers.RayTracer
 			return null;
 		}
 
+		/// <summary>
+		/// Like GetClosestIntersection, but considers the Ray's min and max distance instead.
+		/// </summary>
+		public IntersectInfo GetClosestIntersectionWithinRayDistanceRange(Ray ray)
+		{
+			bool inFront;
+			double distanceToHit = Plane.GetDistanceToIntersection(ray, out inFront);
+			// This will also reject infinity.
+			if (ray.minDistanceToConsider < distanceToHit && distanceToHit < ray.maxDistanceToConsider)
+			{
+				return new IntersectInfo
+				{
+					ClosestHitObject = this,
+					HitType = IntersectionType.FrontFace,
+					HitPosition = ray.origin + ray.directionNormal * distanceToHit,
+					NormalAtHit = Plane.Normal,
+					DistanceToHit = distanceToHit
+				};
+			}
+
+			return null;
+		}
+
 		public override int FindFirstRay(RayBundle rayBundle, int rayIndexToStartCheckingFrom)
 		{
 			throw new NotImplementedException();

--- a/Tests/Agg.Tests/Agg.VectorMath/VectorMathTests.cs
+++ b/Tests/Agg.Tests/Agg.VectorMath/VectorMathTests.cs
@@ -182,6 +182,52 @@ namespace MatterHackers.VectorMath.Tests
 		}
 
 		[Test]
+		public void WorldViewPerspectiveProjectionTests()
+		{
+			var world = new WorldView(1, 1);
+			Assert.IsTrue(world.EyePosition.Equals(Vector3.UnitZ * 7, 1e-3));
+			world.CalculatePerspectiveMatrixOffCenter(567, 123, -200, 5, 55);
+			Assert.IsTrue(world.GetScreenPosition(new Vector3(0, 0, 0)).Equals(new Vector2((567 - 200) / 2.0, 123 / 2.0), 1e-3));
+			Assert.AreEqual(5, world.NearZ, 1e-3);
+			Assert.AreEqual(55, world.FarZ, 1e-3);
+			Assert.AreEqual(4.14213562373095, world.NearPlaneHeightInViewspace, 1e-3);
+			var ray = world.GetRayForLocalBounds(new Vector2((567 - 200) / 2.0, 123)); // top center
+			Assert.AreEqual(WorldView.DefaultPerspectiveVFOVDegrees / 2, MathHelper.RadiansToDegrees(Math.Atan2(ray.directionNormal.Y, -ray.directionNormal.Z)), 1e-3);
+			Assert.IsTrue(new Vector3(0, world.NearPlaneHeightInViewspace / 2, 2).Equals(ray.origin, 1e-3));
+			Assert.AreEqual(world.NearPlaneHeightInViewspace * 2, world.GetViewspaceHeightAtPosition(new Vector3(1, 1, -10)), 1e-3);
+			world.Scale = 3;
+			Assert.AreEqual(world.NearPlaneHeightInViewspace * 2 / 3, world.GetWorldUnitsPerScreenPixelAtPosition(new Vector3(1, 1, (7 - 10) / 3.0)) * 123, 1e-3);
+		}
+
+		[Test]
+		public void WorldViewOrthographicProjectionTests()
+		{
+			var world = new WorldView(1, 1);
+			Assert.IsTrue(world.EyePosition.Equals(Vector3.UnitZ * 7, 1e-3));
+			world.CalculateOrthogrphicMatrixOffCenterWithViewspaceHeight(680, 240, -200, 128, 5, 55);
+			Assert.IsTrue(world.GetScreenPosition(new Vector3(0, 0, 0)).Equals(new Vector2((680 - 200) / 2.0, 240 / 2.0), 1e-3));
+			Assert.IsTrue(world.GetScreenPosition(new Vector3(128, 64, 0)).Equals(new Vector2(680 - 200, 240), 1e-3));
+			Assert.IsTrue(world.GetScreenPosition(new Vector3(-128, -64, 0)).Equals(new Vector2(0, 0), 1e-3));
+			Assert.AreEqual(5, world.NearZ, 1e-3);
+			Assert.AreEqual(55, world.FarZ, 1e-3);
+			Assert.AreEqual(128, world.NearPlaneHeightInViewspace, 1e-3);
+			var ray = world.GetRayForLocalBounds(new Vector2((680 - 200) / 2.0, 240)); // top center
+			Assert.IsTrue(Vector3.UnitZ.Equals(-ray.directionNormal.GetNormal(), 1e-3));
+			Assert.IsTrue(new Vector3(0, 64, 2).Equals(ray.origin, 1e-3));
+			Assert.AreEqual(world.NearPlaneHeightInViewspace, world.GetViewspaceHeightAtPosition(new Vector3(1, 1, -10)), 1e-3);
+			world.Scale = 3;
+			Assert.AreEqual(world.NearPlaneHeightInViewspace / 3, world.GetWorldUnitsPerScreenPixelAtPosition(new Vector3(1, 1, (7 - 10) / 3.0)) * 240, 1e-3);
+		}
+
+		[Test]
+		public void WorldViewEyePositionTests()
+		{
+			var world = new WorldView(1, 1);
+			world.EyePosition = new Vector3(1, 2, 3);
+			Assert.IsTrue(new Vector3(1, 2, 3).Equals(world.EyePosition, 1e-3));
+		}
+
+		[Test]
 		public void FrustumExtractionTests()
 		{
 			{

--- a/Tests/Agg.Tests/Agg.VectorMath/VectorMathTests.cs
+++ b/Tests/Agg.Tests/Agg.VectorMath/VectorMathTests.cs
@@ -193,7 +193,7 @@ namespace MatterHackers.VectorMath.Tests
 			Assert.AreEqual(4.14213562373095, world.NearPlaneHeightInViewspace, 1e-3);
 			var ray = world.GetRayForLocalBounds(new Vector2((567 - 200) / 2.0, 123)); // top center
 			Assert.AreEqual(WorldView.DefaultPerspectiveVFOVDegrees / 2, MathHelper.RadiansToDegrees(Math.Atan2(ray.directionNormal.Y, -ray.directionNormal.Z)), 1e-3);
-			Assert.IsTrue(new Vector3(0, world.NearPlaneHeightInViewspace / 2, 2).Equals(ray.origin, 1e-3));
+			Assert.IsTrue((Vector3.UnitZ * 7).Equals(ray.origin, 1e-3));
 			Assert.AreEqual(world.NearPlaneHeightInViewspace * 2, world.GetViewspaceHeightAtPosition(new Vector3(1, 1, -10)), 1e-3);
 			world.Scale = 3;
 			Assert.AreEqual(world.NearPlaneHeightInViewspace * 2 / 3, world.GetWorldUnitsPerScreenPixelAtPosition(new Vector3(1, 1, (7 - 10) / 3.0)) * 123, 1e-3);

--- a/VectorMath/AxisAlignedBoundingBox.cs
+++ b/VectorMath/AxisAlignedBoundingBox.cs
@@ -37,6 +37,14 @@ namespace MatterHackers.VectorMath
 	{
 		public static AxisAlignedBoundingBox Empty() { return new AxisAlignedBoundingBox(Vector3.PositiveInfinity, Vector3.NegativeInfinity); }
 		public static AxisAlignedBoundingBox Zero() { return new AxisAlignedBoundingBox(Vector3.Zero, Vector3.Zero); }
+		public static AxisAlignedBoundingBox CenteredBox(Vector3 size, Vector3 position = default)
+		{
+			return new AxisAlignedBoundingBox(position - size / 2, position + size / 2);
+		}
+		public static AxisAlignedBoundingBox CenteredHalfExtents(Vector3 halfsize, Vector3 position = default)
+		{
+			return new AxisAlignedBoundingBox(position - halfsize, position + halfsize);
+		}
 
 		public Vector3 MinXYZ;
 		public Vector3 MaxXYZ;
@@ -220,6 +228,23 @@ namespace MatterHackers.VectorMath
 			}
 
 			return Vector3.Zero;
+		}
+
+		/// <summary>
+		/// Get all the corners of the AABB as an array.
+		/// </summary>
+		public Vector3[] GetCorners()
+		{
+			return new Vector3[] {
+				GetTopCorner(0),
+				GetTopCorner(1),
+				GetTopCorner(2),
+				GetTopCorner(3),
+				GetBottomCorner(0),
+				GetBottomCorner(1),
+				GetBottomCorner(2),
+				GetBottomCorner(3),
+			};
 		}
 
 		/// <summary>


### PR DESCRIPTION
Mostly rewriting WorldView. Should remain compatible with the existing implementation, unless `GetWorldPosition` is used.

* Rewritten `CalculateOrthogrphicMatrixOffCenter`.
* Magic constants are named now.
* `EyePosition` can be set.
* Projection transform is updated even if the viewport size is zero.
* Some extra tests for `WorldView`.

This is a dependency of the PR for MatterControl.

Part of the solution for issue https://github.com/MatterHackers/MatterControl/issues/5187.