### PR TITLE
Fix dual contouring implementation

### DIFF
--- a/PolygonMesh/DualContouring/Octree.cs
+++ b/PolygonMesh/DualContouring/Octree.cs
@@ -101,7 +101,7 @@ namespace DualContouring
 
 		public static readonly int[][] edgevmap = new int[12][]
 		{
-			new int[2]{2,4},new int[2]{1,5},new int[2]{2,6},new int[2]{3,7},	// x-axis
+			new int[2]{0,4},new int[2]{1,5},new int[2]{2,6},new int[2]{3,7},	// x-axis
 			new int[2]{0,2},new int[2]{1,3},new int[2]{4,6},new int[2]{5,7},	// y-axis
 			new int[2]{0,1},new int[2]{2,3},new int[2]{4,5},new int[2]{6,7}     // z-axis
 		};
@@ -158,27 +158,30 @@ namespace DualContouring
 
 		public static Vector3 ApproximateZeroCrossingPosition(Func<Vector3, double> f, Vector3 p0, Vector3 p1)
 		{
-			// approximate the zero crossing by finding the min value along the edge
-			double minValue = 100000f;
-			double t = 0f;
-			const int steps = 32;
-			int step = 0;
-			var bestPosition = p0;
-			while (++step < steps)
+			Vector3 bestPosition;
+			double minValue;
+
+			// for initial position, try to approximate the zero crossing using linear interpolation
 			{
+				double d0 = f(p0);
+				double d1 = f(p1);
+				double t = (0 - d0) / (d1 - d0);
+				bestPosition = p0 + ((p1 - p0) * t);
+				minValue = Math.Abs(f(bestPosition));
+			}
+
+			// approximate the zero crossing by finding the min value along the edge
+			const int steps = 32;
+			for (int step = 0; step <= steps; step++)
+			{
+				double t = (double) step / steps;
 				Vector3 p = p0 + ((p1 - p0) * t);
 				double density = Math.Abs(f(p));
 				if (density < minValue)
 				{
 					bestPosition = p;
 					minValue = density;
-					if (minValue < 0)
-					{
-						break;
-					}
 				}
-
-				t += 1.0 / steps;
 			}
 
 			return bestPosition;

--- a/PolygonMesh/DualContouring/SVD.cs
+++ b/PolygonMesh/DualContouring/SVD.cs
@@ -40,8 +40,8 @@ public static class SVD
             return;
         }
 
-        double c = 0, s = 0;
-        Schur2.Rot01(vtav, c, s);
+        double c, s;
+        Schur2.Rot01(vtav, out c, out s);
         Givens.Rot01Post(v, c, s);
     }
 
@@ -52,8 +52,8 @@ public static class SVD
             return;
         }
 
-        double c = 0, s = 0;
-        Schur2.Rot02(vtav, c, s);
+        double c, s;
+        Schur2.Rot02(vtav, out c, out s);
         Givens.Rot02Post(v, c, s);
     }
 
@@ -64,8 +64,8 @@ public static class SVD
             return;
         }
 
-        double c = 0, s = 0;
-        Schur2.Rot12(vtav, c, s);
+        double c, s;
+        Schur2.Rot12(vtav, out c, out s);
         Givens.Rot12Post(v, c, s);
     }
 

--- a/PolygonMesh/DualContouring/Schur2.cs
+++ b/PolygonMesh/DualContouring/Schur2.cs
@@ -27,7 +27,7 @@
 
 public static class Schur2
 {
-    public static void Rot01(SMat3 m, double c, double s)
+    public static void Rot01(SMat3 m, out double c, out double s)
     {
         SVD.CalcSymmetricGivensCoefficients(m.m00, m.m01, m.m11, out c, out s);
         double cc = c * c;
@@ -37,7 +37,7 @@ public static class Schur2
                        ss * m.m00 + mix + cc * m.m11, s * m.m02 + c * m.m12, m.m22);
     }
 
-    public static void Rot02(SMat3 m, double c, double s)
+    public static void Rot02(SMat3 m, out double c, out double s)
     {
         SVD.CalcSymmetricGivensCoefficients(m.m00, m.m02, m.m22, out c, out s);
         double cc = c * c;
@@ -47,7 +47,7 @@ public static class Schur2
                        m.m11, s * m.m01 + c * m.m12, ss * m.m00 + mix + cc * m.m22);
     }
 
-    public static void Rot12(SMat3 m, double c, double s)
+    public static void Rot12(SMat3 m, out double c, out double s)
     {
         SVD.CalcSymmetricGivensCoefficients(m.m11, m.m12, m.m22, out c, out s);
         double cc = c * c;

--- a/Tests/Agg.Tests/Agg.PolygonMesh/MeshTests.cs
+++ b/Tests/Agg.Tests/Agg.PolygonMesh/MeshTests.cs
@@ -431,5 +431,45 @@ namespace MatterHackers.PolygonMesh.UnitTests
 				Assert.IsTrue(renderOredrList[2] == 2);
 			}
 		}
+
+		[Test]
+		public void CreateDualContouringCube()
+		{
+			foreach (var size in new[] { 1, 15, 200 })
+			foreach (var iterations in new[] { 2, 3, 4, 5, 6, 7 })
+			{
+				// apply dual contouring to a box shape
+				// and validate that the generated mesh is a cube
+
+				var box = new DualContouring.Box()
+				{
+					Size = new Vector3(size, size, size)
+				};
+
+				var bounds = box.Bounds;
+				bounds.Expand(.1);
+
+				var octree = DualContouring.Octree.BuildOctree(box.Sdf, bounds.MinXYZ, bounds.Size, iterations, threshold: .001);
+				var mesh = DualContouring.Octree.GenerateMeshFromOctree(octree);
+
+				Assert.AreEqual(12, mesh.Faces.Count);
+				Assert.AreEqual(8, mesh.Vertices.Count);
+
+				var expectedVertices = PlatonicSolids.CreateCube(size, size, size).Vertices
+							.OrderBy(v => v.X)
+							.ThenBy(v => v.Y)
+							.ThenBy(v => v.Z);
+
+				var actualVertices = mesh.Vertices
+							.OrderBy(v => v.X)
+							.ThenBy(v => v.Y)
+							.ThenBy(v => v.Z);
+
+				foreach (var (expected, actual) in expectedVertices.Zip(actualVertices))
+				{
+					Assert.Less((expected - actual).Length, 1e-6);
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
This is my proposal to fix MatterHackers/MatterControl#5193.

It fixes some errors in the implementation and improves function `ApproximateZeroCrossingPosition` by including a linear interpolation in addition to the existing incremental search.