### PR TITLE
fix: enable Shift+Click text selection

### DIFF
--- a/Gui/TextWidgets/InternalTextEditWidget.cs
+++ b/Gui/TextWidgets/InternalTextEditWidget.cs
@@ -625,6 +625,11 @@ namespace MatterHackers.Agg.UI
 						SelectionIndexToStartBefore = CharIndexToInsertBefore;
 						Selecting = false;
 					}
+					else
+					{
+						// Shift+Click: extend selection from existing position
+						Selecting = true;
+					}
 
 					mouseIsDownLeft = true;
 				}


### PR DESCRIPTION
## Summary

When Shift is held during mouse click in text fields, the `Selecting` flag was not being set to true, preventing text selection from being created.

## Fix

Added logic to set `Selecting = true` when Shift+Click occurs, allowing users to select a range of text by:
1. Clicking at the start position (without Shift)
2. Holding Shift and clicking at the end position

This matches the expected behavior documented in the existing test `TextSelectionWithShiftClick`.

## Changes

- `Gui/TextWidgets/InternalTextEditWidget.cs`: Added else branch to set `Selecting = true` when Shift key is held during mouse down event.

## Testing

The existing test `TextSelectionWithShiftClick` in `Tests/Agg.Tests/Agg Automation Tests/TextEditTests.cs` validates this functionality.

Closes #1411